### PR TITLE
Read performance - larger SFTP request size

### DIFF
--- a/app/nacl_src/read_file_command.cc
+++ b/app/nacl_src/read_file_command.cc
@@ -93,7 +93,7 @@ void ReadFileCommand::ReadFileLengthOf(LIBSSH2_SFTP_HANDLE *sftp_handle,
           break;
         } else if (buf_offset >= (buffer_size * 1024)) {
           fprintf(stderr, "Flush\n");
-          OnReadFile(result_buf, buf_offset, false);
+          OnReadFile(result_buf, buf_offset, true);
           //result_buf.clear();
           buf_offset = 0;
         }

--- a/app/nacl_src/read_file_command.cc
+++ b/app/nacl_src/read_file_command.cc
@@ -59,35 +59,43 @@ void ReadFileCommand::ReadFileLengthOf(LIBSSH2_SFTP_HANDLE *sftp_handle,
   throw(CommunicationException)
 {
   int rc = -1;
-  int max_buf_size = 2048;
+  //int max_buf_size = 2048;
   libssh2_uint64_t total = 0;
-  std::vector<unsigned char> result_buf;
-  result_buf.reserve((buffer_size + 1) * 1024);
+  //std::vector<unsigned char> result_buf;
+  //result_buf.reserve((buffer_size + 1) * 1024);
+  const int max_sftp_size = buffer_size * 1024;
+  // SFTP read size is unpredictable, so we have to handle up to 2x chunk size.
+  char result_buf[max_sftp_size * 2];
+  int buf_offset = 0;
   do {
-    int buf_size = std::min((libssh2_uint64_t)max_buf_size, length - total);
-    char mem[buf_size];
-    rc = libssh2_sftp_read(sftp_handle, mem, sizeof(mem));
+    int buf_size = std::min((libssh2_uint64_t)max_sftp_size, length - total);
+    //char mem[buf_size];
+    char* sftp_buffer = result_buf + buf_offset;
+    //rc = libssh2_sftp_read(sftp_handle, mem, sizeof(mem));
+    rc = libssh2_sftp_read(sftp_handle, sftp_buffer, buf_size);
     if (rc == LIBSSH2_ERROR_EAGAIN) {
       WaitSocket(GetServerSock(), GetSession());
     } else if (rc >= 0) {
       total += rc;
-      fprintf(stderr, "buf_size: %d, rc:%d total:%llu length:%llu result_buf:%d\n", buf_size, rc, total, length, result_buf.size());
+      buf_offset += rc;
+      fprintf(stderr, "SFTP read buf_size: %d, rc:%d total:%llu length:%llu result_buf:%d\n", buf_size, rc, total, length, buf_offset);
       if (rc == 0) {
         fprintf(stderr, "Reading completed - 2\n");
-        OnReadFile(result_buf, false);
+        OnReadFile(result_buf, buf_offset, false);
         break;
       } else {
-        for (int i = 0; i < rc; i++) {
-          result_buf.push_back(mem[i]);
-        }
+        //for (int i = 0; i < rc; i++) {
+        //  result_buf.push_back(mem[i]);
+        //}
         if (length <= total) {
           fprintf(stderr, "Reading completed - 1\n");
-          OnReadFile(result_buf, false);
+          OnReadFile(result_buf, buf_offset, false);
           break;
-        } else if (result_buf.size() >= (buffer_size * 1024)) {
+        } else if (buf_offset >= (buffer_size * 1024)) {
           fprintf(stderr, "Flush\n");
-          OnReadFile(result_buf, true);
-          result_buf.clear();
+          OnReadFile(result_buf, buf_offset, false);
+          //result_buf.clear();
+          buf_offset = 0;
         }
       }
     } else {
@@ -96,16 +104,18 @@ void ReadFileCommand::ReadFileLengthOf(LIBSSH2_SFTP_HANDLE *sftp_handle,
   } while (1);
 }
 
-void ReadFileCommand::OnReadFile(const std::vector<unsigned char> &result_buf, bool has_more)
+void ReadFileCommand::OnReadFile(const char *result_buf, int length, bool has_more)
 {
-  pp::VarArrayBuffer buffer(result_buf.size());
+  pp::VarArrayBuffer buffer(length);
   char* data = static_cast<char*>(buffer.Map());
+  memcpy(data, result_buf, length);
+  /*
   std::vector<unsigned char>::const_iterator i;
   int cnt = 0;
   for (i = result_buf.begin(); i != result_buf.end(); ++i) {
     unsigned char value = *i;
     data[cnt] = value;
     cnt++;
-  }
-  GetListener()->OnReadFile(GetRequestID(), buffer, result_buf.size(), has_more);
+  }  */
+  GetListener()->OnReadFile(GetRequestID(), buffer, length, has_more);
 }

--- a/app/nacl_src/read_file_command.cc
+++ b/app/nacl_src/read_file_command.cc
@@ -66,7 +66,7 @@ void ReadFileCommand::ReadFileLengthOf(LIBSSH2_SFTP_HANDLE *sftp_handle,
   const int max_sftp_size = buffer_size * 1024;
   // SFTP read size is unpredictable, so we have to handle up to 2x chunk size.
   char result_buf[max_sftp_size * 2];
-  int buf_offset = 0;
+  unsigned int buf_offset = 0;
   do {
     int buf_size = std::min((libssh2_uint64_t)max_sftp_size, length - total);
     //char mem[buf_size];

--- a/app/nacl_src/read_file_command.cc
+++ b/app/nacl_src/read_file_command.cc
@@ -59,19 +59,14 @@ void ReadFileCommand::ReadFileLengthOf(LIBSSH2_SFTP_HANDLE *sftp_handle,
   throw(CommunicationException)
 {
   int rc = -1;
-  //int max_buf_size = 2048;
   libssh2_uint64_t total = 0;
-  //std::vector<unsigned char> result_buf;
-  //result_buf.reserve((buffer_size + 1) * 1024);
   const int max_sftp_size = buffer_size * 1024;
   // SFTP read size is unpredictable, so we have to handle up to 2x chunk size.
   char result_buf[max_sftp_size * 2];
   unsigned int buf_offset = 0;
   do {
     int buf_size = std::min((libssh2_uint64_t)max_sftp_size, length - total);
-    //char mem[buf_size];
     char* sftp_buffer = result_buf + buf_offset;
-    //rc = libssh2_sftp_read(sftp_handle, mem, sizeof(mem));
     rc = libssh2_sftp_read(sftp_handle, sftp_buffer, buf_size);
     if (rc == LIBSSH2_ERROR_EAGAIN) {
       WaitSocket(GetServerSock(), GetSession());
@@ -84,9 +79,6 @@ void ReadFileCommand::ReadFileLengthOf(LIBSSH2_SFTP_HANDLE *sftp_handle,
         OnReadFile(result_buf, buf_offset, false);
         break;
       } else {
-        //for (int i = 0; i < rc; i++) {
-        //  result_buf.push_back(mem[i]);
-        //}
         if (length <= total) {
           fprintf(stderr, "Reading completed - 1\n");
           OnReadFile(result_buf, buf_offset, false);
@@ -94,7 +86,6 @@ void ReadFileCommand::ReadFileLengthOf(LIBSSH2_SFTP_HANDLE *sftp_handle,
         } else if (buf_offset >= (buffer_size * 1024)) {
           fprintf(stderr, "Flush\n");
           OnReadFile(result_buf, buf_offset, true);
-          //result_buf.clear();
           buf_offset = 0;
         }
       }
@@ -109,13 +100,5 @@ void ReadFileCommand::OnReadFile(const char *result_buf, int length, bool has_mo
   pp::VarArrayBuffer buffer(length);
   char* data = static_cast<char*>(buffer.Map());
   memcpy(data, result_buf, length);
-  /*
-  std::vector<unsigned char>::const_iterator i;
-  int cnt = 0;
-  for (i = result_buf.begin(); i != result_buf.end(); ++i) {
-    unsigned char value = *i;
-    data[cnt] = value;
-    cnt++;
-  }  */
   GetListener()->OnReadFile(GetRequestID(), buffer, length, has_more);
 }

--- a/app/nacl_src/read_file_command.h
+++ b/app/nacl_src/read_file_command.h
@@ -40,7 +40,7 @@ class ReadFileCommand : protected AbstractCommand
                         const libssh2_uint64_t length,
                         const unsigned int buffer_size)
     throw(CommunicationException);
-  void OnReadFile(const std::vector<unsigned char> &result_buf, bool has_more);
+  void OnReadFile(const char* result_buf, int length, bool has_more);
 
 };
 


### PR DESCRIPTION
Please take a look at these changes. I have gone from a 2K SFTP request size to 32K (based on JavaScript buffer size) and eliminated the intermediate vector of chars, which has approximately doubled my performance. I went from about 5 Mbit/sec to about 10 Mbit/sec on my local network.

I believe most of the gain is due to the large SFTP request size, even though the client always comes back with 2000 bytes at a time; libssh2 is actually pipelining the requests more efficiently behind the scenes.